### PR TITLE
Fix output parsing for recent versions of sonnet

### DIFF
--- a/pysonnet/sonnet.py
+++ b/pysonnet/sonnet.py
@@ -28,9 +28,11 @@ def test_sonnet(sonnet_path):
     with psutil.Popen([em_path, "-test"], stdout=subprocess.PIPE,
                       stderr=subprocess.PIPE) as process:
         while True:
-            line = process.stdout.readline().decode('utf-8').strip()
-            error = process.stderr.readline().decode('utf-8').strip()
-            if not line and not error and process.poll() is not None:
+            line_raw = process.stdout.readline()
+            error_raw = process.stderr.readline()
+            line = line_raw.decode('utf-8').strip()
+            error = error_raw.decode('utf-8').strip()
+            if not line_raw and not error_raw and process.poll() is not None:
                 break
             if error:
                 log.error(error)


### PR DESCRIPTION
Recent versions of sonnet start the output of this test with a newline and exit before `test_sonnet` has a chance to parse any of the input. Because `line` and `error` have newlines stripped the program erroneously interprets this as EOF and concludes that em did not output anything.

Error:
```python

In [2]: test_sonnet("/opt/sonnet")
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
Cell In [2], line 1
----> 1 test_sonnet("/opt/sonnet")

File ~/Workspace/pysonnet/pysonnet/sonnet.py:51, in test_sonnet(sonnet_path)
     48             success = True
     50 if not success:
---> 51     raise RuntimeError("The sonnet test was unsuccessful.")
     52 if not version:
     53     raise RuntimeError("The sonnet version could not be determined.")

RuntimeError: The sonnet test was unsuccessful.
```

Sonnet Output:
```
(nicks-masks) ➜  python git:(master) ✗ /opt/sonnet/bin/em -test           

               ELECTROMAGNETIC ANALYSIS OF 3-D PLANAR CIRCUITS
                                 Version 18.56

                Copyright (c) 1986-2022 Sonnet Software Inc.
                             All rights reserved.

Run 1:  Thu Oct 20 13:56:42 2022.  ucsb2.2.52045.
        Em version 18.56 (64-bit LNX-86) on glados local.

  Project:  /home/cudaa/Workspace/artwork/Nick/python/test.son.

    Begin electromagnetic simulation using frequency sweep:
      Single Frequency = 1 GHZ

    Frequency:  1 GHZ
      Subsectioning time:  0 seconds.
      Circuit requires 1 subsection and 1 MB of memory.
      Threads:  using 64 thread(s), 128 core(s) available.
      Waveguide mode time:  0 seconds.
      Matrix fill time:  0 seconds.
      Matrix solve time:  0 seconds.

      De-embedded S-Parameters. 50 Ohm Port Terminations.
      Magnitude/Angle. Touchstone Format. Matrix Order (line #1: S11 S12 S13 ...).
      1.00000000 1.000000 -0.260
      ! P1 F=1.0 Eeff=(1.00693 + j0) Z0=(152.57 + j0)
      Total time per frequency:  0 seconds.

    Post-Analysis information for em run 1:
      Total time for 1 frequency:  0 seconds.
      Em errors detected: 0    Em warnings detected: 0.

Em simulation completed Thu Oct 20 13:56:42 2022.
```